### PR TITLE
fix: folder setting wont dismiss issue.

### DIFF
--- a/app/src/main/java/com/olup/notable/views/HomeView.kt
+++ b/app/src/main/java/com/olup/notable/views/HomeView.kt
@@ -137,12 +137,12 @@ fun Library(navController: NavController, folderId: String? = null) {
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     items(folders!!) { folder ->
-                        var isSettingsOpen by remember { mutableStateOf(false) }
-                        if (isSettingsOpen) FolderConfigDialog(
+                        var isFolderSettingsOpen by remember { mutableStateOf(false) }
+                        if (isFolderSettingsOpen) FolderConfigDialog(
                             folderId = folder.id,
                             onClose = {
                                 Log.i(TAG, "Closing Directory Dialog")
-                                isSettingsOpen = false
+                                isFolderSettingsOpen = false
                             })
 
                         Row(
@@ -152,7 +152,7 @@ fun Library(navController: NavController, folderId: String? = null) {
                                         navController.navigate("library?folderId=${folder.id}")
                                     },
                                     onLongClick = {
-                                        isSettingsOpen = true
+                                        isFolderSettingsOpen = !isFolderSettingsOpen
                                     },
                                 )
                                 .border(0.5.dp, Color.Black)


### PR DESCRIPTION
## Summary
When editing folder name, the dialog won't be dismissed.

## Root Cause
* Using the wrong flag.
* Strange behavior that it will run into onLongClick expression of Row. So it's better to use value toggling instead of assigning tru.
* 
## Solution
Create a new flag for controlling show/hide of font setting dialog.
