### PR TITLE
Custom save/export path

### DIFF
--- a/app/src/main/java/com/olup/notable/components/Path.kt
+++ b/app/src/main/java/com/olup/notable/components/Path.kt
@@ -1,0 +1,65 @@
+package com.olup.notable.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowDropDown
+import androidx.compose.material.icons.rounded.Edit
+import androidx.compose.material.icons.sharp.Edit
+import androidx.compose.material.icons.sharp.KeyboardArrowDown
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import com.olup.notable.noRippleClickable
+
+// It seems wrong to re-implement a Path selector dialog,
+// but until now I only saw self drawed UI elements, not built-in android ones
+// It should be simple, if I only render a text,
+// and if it is clicked upon I open a Directory Selector Dialog
+@Composable
+fun PathMenu(value: String, onChange: (String) -> Unit) {
+    var isExpanded by remember { mutableStateOf(false) }
+
+    Box() {
+        Row() {
+            Text(text = value,
+                fontWeight = FontWeight.Light,
+                modifier = Modifier.noRippleClickable { isExpanded = true })
+                // Register Directory selector dialog on Click event
+            )
+
+            Icon(
+                Icons.Rounded.ArrowDropDown, contentDescription = "open select",
+                modifier = Modifier.height(20.dp)
+            )
+            
+        if (isExpanded) Popup(onDismissRequest = { isExpanded = false }) {
+            Column(
+                modifier = Modifier
+                    .width(IntrinsicSize.Max)
+                    .border(0.5.dp, Color.Black, RectangleShape)
+                    .background(Color.White)
+            ) {
+                Text(text = "dialogOpens", // as I am new to Android, first test if the changes until now work
+                    fontWeight = FontWeight.Light,
+                    color = Color.Black,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.White)
+                        .padding(20.dp, 10.dp)
+                        .noRippleClickable {
+                            //onChange(it.first)
+                            isExpanded = false
+                        })
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/olup/notable/modals/AppSettings.kt
+++ b/app/src/main/java/com/olup/notable/modals/AppSettings.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.olup.notable.components.SelectMenu
+import com.olup.notable.components.PathMenu
 import com.olup.notable.db.KvProxy
 import kotlin.concurrent.thread
 
@@ -25,6 +26,7 @@ import kotlin.concurrent.thread
 data class AppSettings(
         val version: Int,
         val defaultNativeTemplate: String = "blank",
+        val defaultSavePath: Srting = Environment.DIRECTORY_DOCUMENTS / "notable",
         val quickNavPages: List<String> = listOf()
 )
 
@@ -62,6 +64,23 @@ fun AppSettingsModal(onClose: () -> Unit) {
             Box(Modifier.height(0.5.dp).fillMaxWidth().background(Color.Black))
 
             Column(Modifier.padding(20.dp, 10.dp)) {
+                Row() {
+                    Text(text = "Save path")
+                    Spacer(Modifier.width(10.dp))
+                    PathMenu(
+                            onChange = {
+                                kv.setKv(
+                                        "APP_SETTINGS",
+                                        settings!!.copy(defaultSavePath = it),
+                                        AppSettings.serializer()
+                                )
+                            },
+                            value = settings?.defaultSavePath ?: Environment.DIRECTORY_DOCUMENTS / "notable"
+                    )
+                }
+
+                Spacer(Modifier.height(10.dp))
+
                 Row() {
                     Text(text = "Default Page Background Template")
                     Spacer(Modifier.width(10.dp))

--- a/app/src/main/java/com/olup/notable/utils/page.kt
+++ b/app/src/main/java/com/olup/notable/utils/page.kt
@@ -6,6 +6,7 @@ import android.os.Environment
 import androidx.compose.ui.unit.IntOffset
 import com.olup.notable.db.BookRepository
 import com.olup.notable.db.PageRepository
+import com.olup.notable.db.appRepository
 import com.olup.notable.db.Stroke
 import io.shipbook.shipbooksdk.Log
 import java.io.FileOutputStream
@@ -31,8 +32,16 @@ fun exportPage(context: Context, pageId: String) {
 private inline fun exportPdf(dir: String, name: String, write: PdfDocument.() -> Unit) {
     val document = PdfDocument()
     document.write()
+
+    val context = LocalContext.current
+    val appRepository = AppRepository(context)
+
+    val savePath = appRepository.kvProxy.get(
+                                    "APP_SETTINGS", AppSettings.serializer()
+                                )?.defaultSavePath ?: Environment.DIRECTORY_DOCUMENTS / "notable"
+
     val filePath = Environment.getExternalStorageDirectory().toPath() /
-            Environment.DIRECTORY_DOCUMENTS / "notable" / dir / "$name.pdf"
+            savePath / dir / "$name.pdf"
     Files.createDirectories(filePath.parent)
     FileOutputStream(filePath.absolutePathString()).use(document::writeTo)
     document.close()

--- a/app/src/main/java/com/olup/notable/utils/utils.kt
+++ b/app/src/main/java/com/olup/notable/utils/utils.kt
@@ -249,7 +249,7 @@ fun handleSelect(
 }
 
 
-// touchpoints is in wiew coordinates
+// touchpoints is in view coordinates
 fun handleDraw(
     page: PageView,
     historyBucket: MutableList<String>,


### PR DESCRIPTION
A new global setting `defaultSavePath`, aka "Save path" is introduced, where all exported PDF is put.

This feature would enable "one-way-sync" (aka backup), with 3rd party apps.

Limitations:
  - During export, files will be overwritten.
    If any other application changes the PDFs created by Notable, those changes will be lost during any later export.
  - Only changes "exported" are synced, see "Auto export" later.

Challenges:
  - The Android permission system may not be so trivial, but it depends on the 3rd party app's capabilities and created directory permission settings.

Related thread and comment:
    https://discord.com/channels/1086542019415003227/1087678050507952128/1109180795077263420