### PR TITLE
Fix Note Air 3 - Add Hidden API Bypass for SDK30+ and init RxManager from newly added …

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,6 +98,8 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-compat'
         exclude group: 'com.android.support', module: 'appcompat-v7'
     }
+    implementation("org.lsposed.hiddenapibypass:hiddenapibypass:4.3") // required by onyx sdk
+
     // used in RawInputManager.
     implementation group: 'io.reactivex.rxjava2', name: 'rxjava', version: '2.2.21'
     implementation group: 'io.reactivex.rxjava2', name: 'rxandroid', version: '2.1.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".NotableApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/olup/notable/NotableApp.kt
+++ b/app/src/main/java/com/olup/notable/NotableApp.kt
@@ -1,0 +1,21 @@
+package com.olup.notable
+
+import android.app.Application
+import com.onyx.android.sdk.rx.RxManager
+import org.lsposed.hiddenapibypass.HiddenApiBypass
+
+class NotableApp : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        RxManager.Builder.initAppContext(this)
+        checkHiddenApiBypass()
+    }
+
+    private fun checkHiddenApiBypass() {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+            HiddenApiBypass.addHiddenApiExemptions("")
+        }
+    }
+
+}


### PR DESCRIPTION
Seems like SDK30+ adds some trouble for the Onyx SDK and this "HiddenAPIBypass" is their work-around.